### PR TITLE
Fix error while adding coco_category_list

### DIFF
--- a/labelme2coco/labelme2coco.py
+++ b/labelme2coco/labelme2coco.py
@@ -31,7 +31,7 @@ def get_coco_from_labelme_folder(
     coco = Coco()
 
     if coco_category_list is not None:
-        coco.add_3fdc_from_coco_category_list(coco_category_list)
+        coco.add_categories_from_coco_category_list(coco_category_list)
 
     # parse labelme annotations
     category_ind = 0


### PR DESCRIPTION
Orginal function: coco.add_3fdc_from_coco_category_list(coco_category_list) 
caused error: 'Coco' object has no attribute 'add_3fdc_from_coco_category_list'. 

It doesn't exist in the recommended version of the sahi library 0.8.19. Changing following line for: coco.add_categories_from_coco_category_list(coco_category_list) fix the problem.